### PR TITLE
Add macOS support for BeamerQt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,108 @@
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon?
+._*
+.Spotlight-V100
+.Trashes
+
+# Windows thumbnails (harmless on macOS but safe to ignore in cross-platform repos)
+ehthumbs.db
+Thumbs.db
+
+# Python bytecode and caches
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+.conda/
+.mamba/
+
+# Packaging / build
+build/
+dist/
+.eggs/
+*.egg-info/
+*.egg
+pip-wheel-metadata/
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Type checkers
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.pyre/
+.pytype/
+.ruff_cache/
+
+# Editors/IDEs
+.vscode/
+.idea/
+*.code-workspace
+
+# Jupyter
+.ipynb_checkpoints/
+
+# Logs and local databases
+*.log
+*.sqlite3
+
+# Qt / QML compiled caches
+*.qmlc
+*.jsc
+
+# Project-specific: transient folders created during LaTeX/PDF generation
+# These are created under temp dirs named by the app; ignore them anywhere.
+**/LaTeX/
+**/Doc/
+**/Media/
+**/SlidesPrev/
+
+# LaTeX build artifacts (keep PDFs tracked if you want; uncomment *.pdf to ignore globally)
+*.aux
+*.bbl
+*.bcf
+*.blg
+*.fdb_latexmk
+*.fls
+*.lof
+*.log
+*.lol
+*.lot
+*.nav
+*.out
+*.run.xml
+*.snm
+*.synctex.gz
+*.toc
+*.vrb
+# *.pdf
+
+
+# Previews of templates
+Previews/

--- a/core/beamerDocument.py
+++ b/core/beamerDocument.py
@@ -234,6 +234,8 @@ class beamerDocument():
         
         if LocalSystem == "Windows":
             os.startfile(self.latexfolder)
+        elif LocalSystem == "Darwin":
+            subprocess.call(('open', self.latexfolder))
         else:
             subprocess.call(('xdg-open', self.latexfolder))
         
@@ -353,6 +355,8 @@ class beamerDocument():
         if self.ShowPreview:
             if LocalSystem == "Windows":
                 os.startfile('output.pdf')
+            elif LocalSystem == "Darwin":
+                subprocess.call(('open', "output.pdf"))
             else:
                 subprocess.call(('xdg-open', 'output.pdf'))
         
@@ -458,6 +462,8 @@ class beamerDocument():
         if ShowPreview:
             if LocalSystem == "Windows":
                 os.startfile('output.pdf')
+            elif LocalSystem == "Darwin":
+                subprocess.call(('open', 'output.pdf'))
             else:
                 subprocess.call(('xdg-open', 'output.pdf'))
         

--- a/main.py
+++ b/main.py
@@ -21,6 +21,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from PyQt6 import QtWidgets
 from gui.mainwindow import *
 import shutil
+import multiprocessing
+import platform
+import sys
 
 
 def main():
@@ -41,4 +44,11 @@ def main():
     
     
 if __name__ == "__main__":
+    # macOS multiprocessing compatibility fix
+    if platform.system() == "Darwin":
+        try:
+            multiprocessing.set_start_method("fork")
+        except RuntimeError:
+            pass
+
     main()


### PR DESCRIPTION
- Replace 'xdg-open' with the 'open' command for macOS in `beamerDocument.py`
- Add platform detection for Darwin system
- Fix file/folder opening functionality on macOS
- Add macOS multiprocessing compatibility fix in `main.py`
- Add a comprehensive .gitignore for cross-platform development

Tested on macOS Sequoia 15.6 with Apple Silicon M4